### PR TITLE
Add missing 'J' key mapping in translateToKeybd

### DIFF
--- a/keyboard_emulate.go
+++ b/keyboard_emulate.go
@@ -78,6 +78,8 @@ func translateToKeybd(s rune) (int, bool) {
 		return keybd_event.VK_H, false
 	case 'I':
 		return keybd_event.VK_I, false
+	case 'J':
+    	return keybd_event.VK_J, false
 	case 'K':
 		return keybd_event.VK_K, false
 	case 'L':


### PR DESCRIPTION
Thanks for this useful project! 

While using it, I noticed that the letter `'J'`  was not included in the `translateToKeybd` mapping.  
This PR simply adds the missing mapping:  
- `'J'` → `keybd_event.VK_J`

Hope this small fix can be helpful. Thanks for reviewing 🙏
